### PR TITLE
API19 compatibility

### DIFF
--- a/library/src/main/java/me/zhanghai/android/materialprogressbar/MaterialProgressBar.java
+++ b/library/src/main/java/me/zhanghai/android/materialprogressbar/MaterialProgressBar.java
@@ -297,11 +297,11 @@ public class MaterialProgressBar extends ProgressBar {
         if (tint.mHasTintList || tint.mHasTintMode) {
 
             if (tint.mHasTintList) {
-                drawable.setTintList(tint.mTintList);
+                ((ProgressDrawableBase) drawable).setTintList(tint.mTintList);
             }
 
             if (tint.mHasTintMode) {
-                drawable.setTintMode(tint.mTintMode);
+                ((ProgressDrawableBase) drawable).setTintMode(tint.mTintMode);
             }
 
             // The drawable (or one of its children) may not have been


### PR DESCRIPTION
Fix a crash on API19 and below where method lookups on the Drawable class failed because the methods were not available on this API level.

How to reproduce: Add `android:tint` attribute to one of the MaterialProgressBar definitions in your sample application.

Tested on KitKat 4.4.2 and Lollipop.
