### PR TITLE
Tinting for secondary progress and background track

### DIFF
--- a/library/src/main/java/me/zhanghai/android/materialprogressbar/HorizontalProgressDrawable.java
+++ b/library/src/main/java/me/zhanghai/android/materialprogressbar/HorizontalProgressDrawable.java
@@ -124,4 +124,22 @@ public class HorizontalProgressDrawable extends LayerDrawable
         mSecondaryProgressDrawable.setTintMode(tintMode);
         mProgressDrawable.setTintMode(tintMode);
     }
+
+    /**
+     * Specifies tint color for the secondary progress.
+     *
+     * @param tintColor Color to use for tinting secondary progress
+     */
+    public void setSecondaryTint(@ColorInt int tintColor) {
+        mSecondaryProgressDrawable.setTint(tintColor);
+    }
+
+    /**
+     * Specifies tint color for the background track.
+     *
+     * @param tintColor Color to use for tinting the background track
+     */
+    public void setTrackTint(@ColorInt int tintColor) {
+        mTrackDrawable.setTint(tintColor);
+    }
 }


### PR DESCRIPTION
This PR adds two methods to the `HorizontalProgressDrawable`, enabling users to tint the secondary progress drawable and the track drawable separately from the main progress one.

Please let me know if I missed anything, or if this could be done in a better way. Thank you for this great piece of code! :-)
