### PR TITLE
setLayerType to SOFTWARE so progress bar won't look blurry; fix #30

### DIFF
--- a/library/src/main/java/me/zhanghai/android/materialprogressbar/HorizontalProgressDrawable.java
+++ b/library/src/main/java/me/zhanghai/android/materialprogressbar/HorizontalProgressDrawable.java
@@ -21,7 +21,7 @@ import me.zhanghai.android.materialprogressbar.internal.ThemeUtils;
  * A backported {@code Drawable} for determinate horizontal {@code ProgressBar}.
  */
 public class HorizontalProgressDrawable extends LayerDrawable
-        implements IntrinsicPaddingDrawable, ShowTrackDrawable, TintableDrawable {
+        implements IntrinsicPaddingDrawable, ShowTrackDrawable, TintableDrawable, RTLableDrawable {
 
     private int mSecondaryAlpha;
     private SingleHorizontalProgressDrawable mTrackDrawable;
@@ -32,8 +32,9 @@ public class HorizontalProgressDrawable extends LayerDrawable
      * Create a new {@code HorizontalProgressDrawable}.
      *
      * @param context the {@code Context} for retrieving style information.
+     * @param rtl true for right-to-left progressbar, false for left-to-right
      */
-    public HorizontalProgressDrawable(Context context) {
+    public HorizontalProgressDrawable(Context context, boolean rtl) {
         super(new Drawable[] {
                 new SingleHorizontalProgressDrawable(context),
                 new SingleHorizontalProgressDrawable(context),
@@ -49,10 +50,12 @@ public class HorizontalProgressDrawable extends LayerDrawable
         mSecondaryAlpha = Math.round(disabledAlpha * 0xFF);
         mSecondaryProgressDrawable.setAlpha(mSecondaryAlpha);
         mSecondaryProgressDrawable.setShowTrack(false);
+        mSecondaryProgressDrawable.setRTL(rtl);
 
         setId(2, android.R.id.progress);
         mProgressDrawable = (SingleHorizontalProgressDrawable) getDrawable(2);
         mProgressDrawable.setShowTrack(false);
+        mProgressDrawable.setRTL(rtl);
     }
 
     /**
@@ -123,5 +126,25 @@ public class HorizontalProgressDrawable extends LayerDrawable
         mTrackDrawable.setTintMode(tintMode);
         mSecondaryProgressDrawable.setTintMode(tintMode);
         mProgressDrawable.setTintMode(tintMode);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isRTL() {
+        return mTrackDrawable.isRTL();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setRTL(boolean rtl) {
+        if (mTrackDrawable.isRTL() != rtl) {
+            mTrackDrawable.setRTL(rtl);
+            mSecondaryProgressDrawable.setRTL(rtl);
+            invalidateSelf();
+        }
     }
 }

--- a/library/src/main/java/me/zhanghai/android/materialprogressbar/IndeterminateHorizontalProgressDrawable.java
+++ b/library/src/main/java/me/zhanghai/android/materialprogressbar/IndeterminateHorizontalProgressDrawable.java
@@ -18,7 +18,7 @@ import me.zhanghai.android.materialprogressbar.internal.ThemeUtils;
  * A backported {@code Drawable} for indeterminate horizontal {@code ProgressBar}.
  */
 public class IndeterminateHorizontalProgressDrawable extends IndeterminateProgressDrawableBase
-        implements ShowTrackDrawable {
+        implements ShowTrackDrawable, RTLableDrawable {
 
     private static final float PROGRESS_INTRINSIC_HEIGHT_DP = 3.2f;
     private static final float PADDED_INTRINSIC_HEIGHT_DP = 16;
@@ -31,6 +31,7 @@ public class IndeterminateHorizontalProgressDrawable extends IndeterminateProgre
     private int mProgressIntrinsicHeight;
     private int mPaddedIntrinsicHeight;
     private boolean mShowTrack = true;
+    private boolean mRTL = false;
     private float mTrackAlpha;
 
     private RectTransformX mRect1TransformX = new RectTransformX(RECT_1_TRANSFORM_X);
@@ -121,6 +122,25 @@ public class IndeterminateHorizontalProgressDrawable extends IndeterminateProgre
         canvas.drawRect(RECT_PROGRESS, paint);
 
         canvas.restoreToCount(saveCount);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isRTL() {
+        return mRTL;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setRTL(boolean rtl) {
+        if (mRTL != rtl) {
+            mRTL = rtl;
+            invalidateSelf();
+        }
     }
 
     private static class RectTransformX {

--- a/library/src/main/java/me/zhanghai/android/materialprogressbar/MaterialProgressBar.java
+++ b/library/src/main/java/me/zhanghai/android/materialprogressbar/MaterialProgressBar.java
@@ -81,6 +81,7 @@ public class MaterialProgressBar extends ProgressBar {
                     R.styleable.MaterialProgressBar_mpb_tintMode, -1), null);
             mProgressTint.mHasTintMode = true;
         }
+        boolean isRTL = a.getBoolean(R.styleable.MaterialProgressBar_mpb_rtl, false);
         a.recycle();
 
         switch (mProgressStyle) {
@@ -101,7 +102,7 @@ public class MaterialProgressBar extends ProgressBar {
                     }
                 }
                 if (!isIndeterminate() || setBothDrawables) {
-                    setProgressDrawable(new HorizontalProgressDrawable(context));
+                    setProgressDrawable(new HorizontalProgressDrawable(context, isRTL));
                 }
                 break;
             default:
@@ -109,6 +110,7 @@ public class MaterialProgressBar extends ProgressBar {
         }
         setUseIntrinsicPadding(useIntrinsicPadding);
         setShowTrack(showTrack);
+        setRTL(isRTL);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
             setLayerType(LAYER_TYPE_SOFTWARE, null);
@@ -200,6 +202,26 @@ public class MaterialProgressBar extends ProgressBar {
         Drawable indeterminateDrawable = getIndeterminateDrawable();
         if (indeterminateDrawable instanceof ShowTrackDrawable) {
             ((ShowTrackDrawable) indeterminateDrawable).setShowTrack(showTrack);
+        }
+    }
+
+    public boolean isRTL() {
+        Drawable drawable = getDrawable();
+        if (drawable instanceof RTLableDrawable) {
+            return ((RTLableDrawable) drawable).isRTL();
+        } else {
+            return false;
+        }
+    }
+
+    public void setRTL(boolean rtl) {
+        Drawable drawable = getDrawable();
+        if (drawable instanceof RTLableDrawable) {
+            ((RTLableDrawable) drawable).setRTL(rtl);
+        }
+        Drawable indeterminateDrawable = getIndeterminateDrawable();
+        if (indeterminateDrawable instanceof RTLableDrawable) {
+            ((RTLableDrawable) indeterminateDrawable).setRTL(rtl);
         }
     }
 

--- a/library/src/main/java/me/zhanghai/android/materialprogressbar/MaterialProgressBar.java
+++ b/library/src/main/java/me/zhanghai/android/materialprogressbar/MaterialProgressBar.java
@@ -109,6 +109,10 @@ public class MaterialProgressBar extends ProgressBar {
         }
         setUseIntrinsicPadding(useIntrinsicPadding);
         setShowTrack(showTrack);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            setLayerType(LAYER_TYPE_SOFTWARE, null);
+        }
     }
 
     /**

--- a/library/src/main/java/me/zhanghai/android/materialprogressbar/RTLableDrawable.java
+++ b/library/src/main/java/me/zhanghai/android/materialprogressbar/RTLableDrawable.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2015 Zhang Hai <Dreaming.in.Code.ZH@Gmail.com>
+ * All Rights Reserved.
+ */
+
+package me.zhanghai.android.materialprogressbar;
+
+/**
+ * A {@code Drawable} that supports right-to-left layout.
+ */
+public interface RTLableDrawable {
+
+    /**
+     * Get whether this drawable is right-to-left. The default is {@code false}.
+     *
+     * @return Whether this drawable is right-to-left.
+     */
+    boolean isRTL();
+
+    /**
+     * Set whether this drawable should be right-to-left. The default is {@code false}.
+     *
+     * @param rtl Whether this drawable should be right-to-left.
+     */
+    void setRTL(boolean rtl);
+}

--- a/library/src/main/java/me/zhanghai/android/materialprogressbar/SingleHorizontalProgressDrawable.java
+++ b/library/src/main/java/me/zhanghai/android/materialprogressbar/SingleHorizontalProgressDrawable.java
@@ -12,7 +12,7 @@ import android.graphics.RectF;
 
 import me.zhanghai.android.materialprogressbar.internal.ThemeUtils;
 
-class SingleHorizontalProgressDrawable extends ProgressDrawableBase {
+class SingleHorizontalProgressDrawable extends ProgressDrawableBase implements RTLableDrawable, ShowTrackDrawable {
 
     private static final float PROGRESS_INTRINSIC_HEIGHT_DP = 3.2f;
     private static final float PADDED_INTRINSIC_HEIGHT_DP = 16;
@@ -24,6 +24,7 @@ class SingleHorizontalProgressDrawable extends ProgressDrawableBase {
     private int mPaddedIntrinsicHeight;
     private boolean mShowTrack = true;
     private float mTrackAlpha;
+    private boolean mRTL = false;
 
     public SingleHorizontalProgressDrawable(Context context) {
         super(context);
@@ -35,13 +36,36 @@ class SingleHorizontalProgressDrawable extends ProgressDrawableBase {
         mTrackAlpha = ThemeUtils.getFloatFromAttrRes(android.R.attr.disabledAlpha, context);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public boolean getShowTrack() {
         return mShowTrack;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public void setShowTrack(boolean showTrack) {
         if (mShowTrack != showTrack) {
             mShowTrack = showTrack;
+            invalidateSelf();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isRTL() {
+        return mRTL;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setRTL(boolean rtl) {
+        if (mRTL != rtl) {
+            mRTL = rtl;
             invalidateSelf();
         }
     }

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -24,6 +24,7 @@
           ~ drawable, false otherwise.
           -->
         <attr name="mpb_showTrack" format="boolean" />
+        <attr name="mpb_rtl" format="boolean" />
         <attr name="android:tint" />
         <attr name="mpb_tintMode" format="enum">
             <enum name="src_over" value="3" />

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     package="me.zhanghai.android.materialprogressbar.sample" >
 
     <application
+        android:supportsRtl="true"
         android:allowBackup="true"
         android:fullBackupContent="true"
         android:icon="@mipmap/launcher_icon"


### PR DESCRIPTION
canvas.scale() makes progress bar look blurry under some circumstances, setting the layer type to software fix it.
