### PR TITLE
setLayerType to SOFTWARE so progress bar won't look blurry; fix #30

### DIFF
--- a/library/src/main/java/me/zhanghai/android/materialprogressbar/MaterialProgressBar.java
+++ b/library/src/main/java/me/zhanghai/android/materialprogressbar/MaterialProgressBar.java
@@ -109,6 +109,10 @@ public class MaterialProgressBar extends ProgressBar {
         }
         setUseIntrinsicPadding(useIntrinsicPadding);
         setShowTrack(showTrack);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            setLayerType(LAYER_TYPE_SOFTWARE, null);
+        }
     }
 
     /**


### PR DESCRIPTION
canvas.scale() makes progress bar look blurry under some circumstances, setting the layer type to software fix it.
